### PR TITLE
タイマー起動時の修正

### DIFF
--- a/app/src/main/java/jp/co/cyberagent/dojo2020/TimerFragment.kt
+++ b/app/src/main/java/jp/co/cyberagent/dojo2020/TimerFragment.kt
@@ -24,7 +24,7 @@ class TimerFragment: Fragment(){
 
     private var timeValue = 0                              // 秒カウンター
 
-    private val dataFormat = SimpleDateFormat("mm:ss.SS", Locale.getDefault())
+    private val dataFormat = SimpleDateFormat("mm:ss:SS", Locale.getDefault())
 
     private var tappedStartButtonFlag: Int = 0
 


### PR DESCRIPTION
#39 
# 概要
タイマー画面起動時に分と病の間のコロン " : "が ，ドット " . " になってしまっているバグを修正
![スマートフォンを使う女性のイラスト「喜・怒・哀・楽」](https://2.bp.blogspot.com/-U32cYlmQB9s/VaBlcRpzBaI/AAAAAAAAvVg/nALhpcvrI6A/s300/smartphone_woman_angry.png) 